### PR TITLE
Fix the bug that a new line would be appended to last using statement in Windows

### DIFF
--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -37,7 +37,7 @@ export const process = (content: string, options: IFormatConfig): string => {
     try {
         const trimSemiColon = /^\s+|;\s*$/;
         content = replaceCode(content, /(\s*using\s+[.\w]+;)+/gm, rawBlock => {
-            const items = rawBlock.split('\n').filter((l) => l && l.trim().length > 0);
+            const items = rawBlock.replace(/\r/gm, '').split('\n').filter((l) => l && l.trim().length > 0);
             items.sort((a: string, b: string) => {
                 let res = 0;
                 // because we keep lines with indentation and semicolons.


### PR DESCRIPTION
since Windows are using '\r\n' as new lines, the items would all have '\r' after split with '\n', and if after sorting, the last statement has a '\r', vscode would automatically adding another '\n' after it which introduce an extra new line.